### PR TITLE
[FIX]cot: read file with 'r' mode

### DIFF
--- a/cot.py
+++ b/cot.py
@@ -105,7 +105,7 @@ class COT(object):
                 self.Excepcion = "Archivo no encontrado: %s" % filename
                 return False
 
-            archivo = open(filename, "rb")
+            archivo = open(filename, "r")
             if not testing:
                 response = self.client(
                     user=self.Usuario, password=self.Password, file=archivo


### PR DESCRIPTION
Parece ser un error originado por la nueva rama main de pyafipws. En la rama [py3k](https://github.com/reingart/pyafipws/blob/0e1dd352d6dc866f40dc77310e21256e10f64a1b/cot.py#L87) leía los archivos en  modo "r" y en [main](https://github.com/ingadhoc/pyafipws/blob/810bcf8a45c9616348aa5c42939280879c494bde/cot.py#L108) los lee como "rb". 